### PR TITLE
Add standard dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ LABEL com.github.actions.name="ESLint Action"
 LABEL com.github.actions.description="Lint your Javascript projects with inline lint error annotations on pull requests."
 LABEL com.github.actions.icon="code"
 LABEL com.github.actions.color="yellow"
-RUN apt install make gcc g++ python
+RUN apt install make gcc g++ python git
 COPY lib /action/lib
 ENTRYPOINT ["/action/lib/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:14-slim
+FROM node:14
 
 LABEL com.github.actions.name="ESLint Action"
 LABEL com.github.actions.description="Lint your Javascript projects with inline lint error annotations on pull requests."
 LABEL com.github.actions.icon="code"
 LABEL com.github.actions.color="yellow"
-
+RUN apt install make gcc g++ python
 COPY lib /action/lib
 ENTRYPOINT ["/action/lib/entrypoint.sh"]


### PR DESCRIPTION
some versions of node-gyp will fail to build without python installed inside the container 
as seen here https://github.com/frg-fossee/eSim-Cloud/runs/696437029

This PR fixes that. 