### PR TITLE
prevent some weird permission errors later on

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -8,3 +8,5 @@ cd "${2:-.}" || echo "source root not found"
 [ -f package-lock.json ] && npm install
 
 NODE_PATH=node_modules GITHUB_TOKEN="${GITHUB_TOKEN:-${1:-.}}" SOURCE_ROOT=${2:-.} node /action/lib/run.js
+
+rm -rf node_modules # cleanup to prevent some weird permission errors later on 


### PR DESCRIPTION
Uh? Why did you remove that. That's actually required: 

```
error An unexpected error occurred: "EACCES: permission denied, unlink '/home/runner/work/1_011_a_infektionsfall_uebermittellung/1_011_a_infektionsfall_uebermittellung/client/node_modules/.yarn-integrity'".
```
https://github.com/ImisDevelopers/1_011_a_infektionsfall_uebermittellung/runs/703785916